### PR TITLE
add Personal Access Token advice to 401 errors

### DIFF
--- a/source/Server.Tests/AdoApiClientScenarios.cs
+++ b/source/Server.Tests/AdoApiClientScenarios.cs
@@ -92,7 +92,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=29"));
 
             Assert.IsFalse(workItemLinks.Succeeded);
-            Assert.AreEqual("Error while fetching work item comments from Azure DevOps: 500 (InternalServerError)", workItemLinks.FailureReason);
+            Assert.AreEqual("Error while fetching work item comments from Azure DevOps: 500 (InternalServerError).", workItemLinks.FailureReason);
             Assert.AreEqual(2, workItemLinks.Value.Length);
             Assert.AreEqual("5", workItemLinks.Value[0].Id);
             Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=5", workItemLinks.Value[0].LinkUrl);

--- a/source/Server/AdoClients/HttpExtensions.cs
+++ b/source/Server/AdoClients/HttpExtensions.cs
@@ -13,7 +13,12 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
 
         public static string ToDescription(this HttpStatusCode httpStatusCode)
         {
-            return $"{(int) httpStatusCode} ({httpStatusCode})";
+            var description = $"{(int) httpStatusCode} ({httpStatusCode}).";
+            if (httpStatusCode == HttpStatusCode.Unauthorized)
+            {
+                description += " Please confirm the Personal Access Token is configured correctly in Azure DevOps Issue Tracker settings.";
+            }
+            return description;
         }
     }
 }


### PR DESCRIPTION
As discussed with @wordlee, @robpearson during review of OctopusDeploy/docs#466