### PR TITLE
Work around servers that report auth failure with redirect to a sign-in page

### DIFF
--- a/source/Server/AdoClients/HttpExtensions.cs
+++ b/source/Server/AdoClients/HttpExtensions.cs
@@ -18,6 +18,11 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
             {
                 description += " Please confirm the Personal Access Token is configured correctly in Azure DevOps Issue Tracker settings.";
             }
+            else if (httpStatusCode == (HttpStatusCode) HttpJsonClientStatus.SigninPage)
+            {
+                description = "The server returned a sign-in page. Please confirm the Personal Access Token is configured correctly in Azure DevOps Issue Tracker settings.";
+            }
+
             return description;
         }
     }

--- a/source/Server/AdoClients/HttpJsonClient.cs
+++ b/source/Server/AdoClients/HttpJsonClient.cs
@@ -12,6 +12,11 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
         (HttpStatusCode status, JObject jObject) Get(string url, string basicPassword = null);
     }
 
+    public enum HttpJsonClientStatus
+    {
+        SigninPage = -203
+    }
+
     public sealed class HttpJsonClient : IHttpJsonClient
     {
         private readonly HttpClient httpClient = new HttpClient();
@@ -29,9 +34,11 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
             using (var response = httpClient.SendAsync(request).GetAwaiter().GetResult())
             {
                 // Work around servers that report auth failure with redirect to a status 203 html page (in violation of our Accept header)
-                if (response.StatusCode == HttpStatusCode.NonAuthoritativeInformation && response.Content?.Headers?.ContentType?.MediaType == "text/html")
+                if (response.Content?.Headers?.ContentType?.MediaType == "text/html"
+                    && (response.StatusCode == HttpStatusCode.NonAuthoritativeInformation
+                        || response.RequestMessage.RequestUri.AbsolutePath.Contains(@"signin")))
                 {
-                    return (HttpStatusCode.Unauthorized, null);
+                    return ((HttpStatusCode) HttpJsonClientStatus.SigninPage, null);
                 }
 
                 return (

--- a/source/Server/AdoClients/HttpJsonClient.cs
+++ b/source/Server/AdoClients/HttpJsonClient.cs
@@ -28,6 +28,12 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
 
             using (var response = httpClient.SendAsync(request).GetAwaiter().GetResult())
             {
+                // Work around servers that report auth failure with redirect to a status 203 html page (in violation of our Accept header)
+                if (response.StatusCode == HttpStatusCode.NonAuthoritativeInformation && response.Content?.Headers?.ContentType?.MediaType == "text/html")
+                {
+                    return (HttpStatusCode.Unauthorized, null);
+                }
+
                 return (
                     response.StatusCode,
                     ParseJsonOrDefault(response.Content)


### PR DESCRIPTION
Some Azure DevOps servers report auth failure by redirecting to a sign-in page. This PR detects that situation and reports it in the error message, with the usual hint about configuring a Personal Access Token.