### PR TITLE
Add Azure DevOps connectivity test button

### DIFF
--- a/source/Client/AzureDevOpsConfigurationResource.cs
+++ b/source/Client/AzureDevOpsConfigurationResource.cs
@@ -9,7 +9,7 @@ namespace Octopus.Client.Extensibility.IssueTracker.AzureDevOps
     public class AzureDevOpsConfigurationResource : ExtensionConfigurationResource
     {
         public const string BaseUrlDisplayName = "Azure DevOps Base Url";
-        public const string BaseUrlDescription = "Set the base url for the Azure DevOps organization or collection.";
+        public const string BaseUrlDescription = "Set the base url for the Azure DevOps organization or collection or project.";
 
         public AzureDevOpsConfigurationResource()
         {

--- a/source/Server.Tests/AdoApiClientScenarios.cs
+++ b/source/Server.Tests/AdoApiClientScenarios.cs
@@ -29,10 +29,10 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
         {
             var store = CreateSubstituteStore();
             var httpJsonClient = Substitute.For<IHttpJsonClient>();
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/24/workitems?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/24/workitems?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.OK,
                     JObject.Parse(@"{""count"":1,""value"":[{""id"":""2"",""url"":""http://redstoneblock/DefaultCollection/_apis/wit/workItems/2""}]}")));
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/2?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/2?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.OK,
                     JObject.Parse(@"{""id"":2,""fields"":{""System.CommentCount"":0,""System.Title"": ""README has no useful content""}}")));
 
@@ -52,10 +52,10 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
         {
             var store = CreateSubstituteStore();
             var httpJsonClient = Substitute.For<IHttpJsonClient>();
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/24/workitems?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/24/workitems?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.OK,
                     JObject.Parse(@"{""count"":1,""value"":[{""id"":""2"",""url"":""http://redstoneblock/DefaultCollection/_apis/wit/workItems/2""}]}")));
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/2?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/2?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.OK,
                     JObject.Parse(@"{""id"":2,""fields"":{""System.CommentCount"":0,""System.Title"": ""README has no useful content""}}")));
 
@@ -72,13 +72,13 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
         {
             var store = CreateSubstituteStore();
             var httpJsonClient = Substitute.For<IHttpJsonClient>();
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/28/workitems?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/28/workitems?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.OK,
                     JObject.Parse(@"{""count"":1,""value"":[{""id"":""4"",""url"":""http://redstoneblock/DefaultCollection/_apis/wit/workItems/4""}]}")));
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/4?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/4?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.OK,
                     JObject.Parse(@"{""id"":4,""fields"":{""System.CommentCount"":3,""System.Title"":""The README riddle has no answer""}}")));
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/4/comments?api-version=5.0-preview.2", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/4/comments?api-version=4.1-preview.2", "rumor")
                 .Returns((HttpStatusCode.OK, JObject.Parse(@"{""totalCount"":3,""count"":3,""comments"":[{""text"":""= Changelog = N/A""}," +
                                                            @"{""text"":""<div>= Changelog =&nbsp;README <i>riddle</i> now has an answer!</div>""},{""text"":""See also related issue.""}]}")));
 
@@ -97,18 +97,18 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
         {
             var store = CreateSubstituteStore();
             var httpJsonClient = Substitute.For<IHttpJsonClient>();
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/29/workitems?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/29/workitems?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.OK,
                     JObject.Parse(@"{""count"":2,""value"":[{""id"":""5"",""url"":""http://redstoneblock/DefaultCollection/_apis/wit/workItems/5""},"
                                   + @"{""id"":""6"",""url"":""http://redstoneblock/DefaultCollection/_apis/wit/workItems/6""}]}")));
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/5?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/5?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.OK,
                     JObject.Parse(@"{""id"":5,""fields"":{""System.CommentCount"":3,""System.Title"":""The README riddle has no answer""}}")));
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/5/comments?api-version=5.0-preview.2", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/5/comments?api-version=4.1-preview.2", "rumor")
                 .Returns((HttpStatusCode.InternalServerError, null));
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/6?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/6?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.InternalServerError, null));
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/6/comments?api-version=5.0-preview.2", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/6/comments?api-version=4.1-preview.2", "rumor")
                 .Returns((HttpStatusCode.InternalServerError, null));
 
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert).GetBuildWorkItemLinks(
@@ -154,7 +154,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
         {
             var store = CreateSubstituteStore();
             var httpJsonClient = Substitute.For<IHttpJsonClient>();
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/7/workitems?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/7/workitems?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.NotFound,
                     JObject.Parse(@"{""$id"":""1"",""message"":""The requested build 7 could not be found."",""errorCode"":0,""eventId"":3000}")));
 
@@ -170,10 +170,10 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
         {
             var store = CreateSubstituteStore();
             var httpJsonClient = Substitute.For<IHttpJsonClient>();
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/8/workitems?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds/8/workitems?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.OK,
                     JObject.Parse(@"{""count"":1,""value"":[{""id"":""999"",""url"":""http://redstoneblock/DefaultCollection/_apis/wit/workItems/999""}]}")));
-            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/999?api-version=5.0", "rumor")
+            httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/999?api-version=4.1", "rumor")
                 .Returns((HttpStatusCode.NotFound,
                     JObject.Parse(@"{""$id"":""1"",""message"":""TF401232: Work item 999 does not exist."",""errorCode"":0,""eventId"":3200}")));
 

--- a/source/Server.Tests/AdoUrlScenarios.cs
+++ b/source/Server.Tests/AdoUrlScenarios.cs
@@ -32,5 +32,41 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
         {
             Assert.Throws<ArgumentException>(() => AdoBuildUrls.ParseBrowserUrl(browserUrl));
         }
+
+        [TestCase(
+            "https://dev.azure.com/octopus-deploy-test/_apis/projects?api-version=4.1",
+            "https://dev.azure.com/octopus-deploy-test", null)]
+        [TestCase(
+            "https://dev.azure.com/octopus-deploy-test/VSTS.Extensions.TestProject/_apis/build/builds?api-version=4.1",
+            "https://dev.azure.com/octopus-deploy-test",
+            "https://dev.azure.com/octopus-deploy-test/VSTS.Extensions.TestProject")]
+        [TestCase(
+            "https://octopus-deploy-test.visualstudio.com/_apis/projects?api-version=4.1",
+            "https://octopus-deploy-test.visualstudio.com/", null)]
+        [TestCase(
+            "https://octopus-deploy-test.visualstudio.com/VSTS.Extensions.TestProject/_apis/build/builds?api-version=4.1",
+            "https://octopus-deploy-test.visualstudio.com/",
+            "https://octopus-deploy-test.visualstudio.com/VSTS.Extensions.TestProject")]
+        [TestCase(
+            "https://octopus-deploy-test.visualstudio.com/DefaultCollection/VSTS.Extensions.TestProject/_apis/build/builds?api-version=4.1",
+            "https://octopus-deploy-test.visualstudio.com/DefaultCollection",
+            "https://octopus-deploy-test.visualstudio.com/DefaultCollection/VSTS.Extensions.TestProject")]
+        [TestCase(
+            "http://redstoneblock/DefaultCollection/_apis/projects?api-version=4.1",
+            "http://redstoneblock/DefaultCollection", null)]
+        [TestCase(
+            "http://redstoneblock/DefaultCollection/Deployable/_apis/build/builds?api-version=4.1",
+            "http://redstoneblock/DefaultCollection",
+            "http://redstoneblock/DefaultCollection/Deployable")]
+        [TestCase(
+            "http://redstoneblock/DefaultCollection/e120aadd-7a70-4267-9a59-e32c3ebf4e8f/_apis/build/builds?api-version=4.1",
+            "http://redstoneblock/DefaultCollection",
+            "http://redstoneblock/DefaultCollection/e120aadd-7a70-4267-9a59-e32c3ebf4e8f")]
+        public void ValidOrganizationAndProjectUrlsAreParsedCorrectly(string organizationOrProjectUrl, string expOrgUrl, string expProjUrl)
+        {
+            var apu = AdoProjectUrls.ParseOrganizationAndProjectUrls(organizationOrProjectUrl);
+            Assert.AreEqual(expOrgUrl, apu.OrganizationUrl);
+            Assert.AreEqual(expProjUrl, apu.ProjectUrl);
+        }
     }
 }

--- a/source/Server.Tests/AdoUrlScenarios.cs
+++ b/source/Server.Tests/AdoUrlScenarios.cs
@@ -15,12 +15,12 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             "https://dev.azure.com/Barsonax",
             "https://dev.azure.com/Barsonax/Singularity",
             160)]
-        public void ValidBuildBrowserUrlsAreParsedCorrectly(string browserUrl, string expOrgUrl, string expProjUrl, int expBuildId)
+        public void ValidBuildBrowserUrlsAreParsedCorrectly(string browserUrl, string expectedOrgUrl, string expectedProjUrl, int expectedBuildId)
         {
             var abu = AdoBuildUrls.ParseBrowserUrl(browserUrl);
-            Assert.AreEqual(expOrgUrl, abu.OrganizationUrl);
-            Assert.AreEqual(expProjUrl, abu.ProjectUrl);
-            Assert.AreEqual(expBuildId, abu.BuildId);
+            Assert.AreEqual(expectedOrgUrl, abu.OrganizationUrl);
+            Assert.AreEqual(expectedProjUrl, abu.ProjectUrl);
+            Assert.AreEqual(expectedBuildId, abu.BuildId);
         }
 
         [TestCase(null)]
@@ -62,11 +62,11 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             "http://redstoneblock/DefaultCollection/e120aadd-7a70-4267-9a59-e32c3ebf4e8f/_apis/build/builds?api-version=4.1",
             "http://redstoneblock/DefaultCollection",
             "http://redstoneblock/DefaultCollection/e120aadd-7a70-4267-9a59-e32c3ebf4e8f")]
-        public void ValidOrganizationAndProjectUrlsAreParsedCorrectly(string organizationOrProjectUrl, string expOrgUrl, string expProjUrl)
+        public void ValidOrganizationAndProjectUrlsAreParsedCorrectly(string organizationOrProjectUrl, string expectedOrgUrl, string expectedProjUrl)
         {
             var apu = AdoProjectUrls.ParseOrganizationAndProjectUrls(organizationOrProjectUrl);
-            Assert.AreEqual(expOrgUrl, apu.OrganizationUrl);
-            Assert.AreEqual(expProjUrl, apu.ProjectUrl);
+            Assert.AreEqual(expectedOrgUrl, apu.OrganizationUrl);
+            Assert.AreEqual(expectedProjUrl, apu.ProjectUrl);
         }
     }
 }

--- a/source/Server/AdoClients/AdoApiClient.cs
+++ b/source/Server/AdoClients/AdoApiClient.cs
@@ -156,7 +156,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
                 return SuccessOrErrorResult.Failure(comments);
             }
 
-            var releaseNoteRegex = new Regex("^" + Regex.Escape(releaseNotePrefix), RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            var releaseNoteRegex = new Regex("^" + Regex.Escape(releaseNotePrefix), RegexOptions.IgnoreCase);
             // Return (last, if multiple found) comment that matched release note prefix
             var releaseNoteComment = comments.Value
                 ?.LastOrDefault(ct => releaseNoteRegex.IsMatch(ct ?? ""));

--- a/source/Server/AdoClients/AdoApiClient.cs
+++ b/source/Server/AdoClients/AdoApiClient.cs
@@ -49,7 +49,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
             bool testing = false)
         {
             // ReSharper disable once StringLiteralTypo
-            var workItemsUrl = $"{adoBuildUrls.ProjectUrl}/_apis/build/builds/{adoBuildUrls.BuildId}/workitems?api-version=5.0";
+            var workItemsUrl = $"{adoBuildUrls.ProjectUrl}/_apis/build/builds/{adoBuildUrls.BuildId}/workitems?api-version=4.1";
 
             var (status, jObject) = client.Get(workItemsUrl, personalAccessToken ?? GetPersonalAccessToken(adoBuildUrls));
             if (status.HttpStatusCode == HttpStatusCode.NotFound)
@@ -77,7 +77,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
         public SuccessOrErrorResult<(string title, int? commentCount)> GetWorkItem(AdoProjectUrls adoProjectUrls, int workItemId)
         {
             // ReSharper disable once StringLiteralTypo
-            var (status, jObject) = client.Get($"{adoProjectUrls.ProjectUrl}/_apis/wit/workitems/{workItemId}?api-version=5.0",
+            var (status, jObject) = client.Get($"{adoProjectUrls.ProjectUrl}/_apis/wit/workitems/{workItemId}?api-version=4.1",
                 GetPersonalAccessToken(adoProjectUrls));
             if (status.HttpStatusCode == HttpStatusCode.NotFound)
             {
@@ -104,7 +104,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
         public SuccessOrErrorResult<string[]> GetWorkItemComments(AdoProjectUrls adoProjectUrls, int workItemId)
         {
             // ReSharper disable once StringLiteralTypo
-            var (status, jObject) = client.Get($"{adoProjectUrls.ProjectUrl}/_apis/wit/workitems/{workItemId}/comments?api-version=5.0-preview.2",
+            var (status, jObject) = client.Get($"{adoProjectUrls.ProjectUrl}/_apis/wit/workitems/{workItemId}/comments?api-version=4.1-preview.2",
                 GetPersonalAccessToken(adoProjectUrls));
 
             if (status.HttpStatusCode == HttpStatusCode.NotFound)

--- a/source/Server/AdoClients/AdoUrl.cs
+++ b/source/Server/AdoClients/AdoUrl.cs
@@ -19,8 +19,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
 
             {
                 if (string.Equals(uri.Host, "dev.azure.com", StringComparison.OrdinalIgnoreCase)
-                    && Regex.Match(uri.AbsolutePath, @"^/(?<org>[^/]+)(/(?<proj>[^_./:\\~&%;@'""?<>|#$*][^/:\\~&%;@'""?<>|#$*]*))?",
-                            RegexOptions.Compiled)
+                    && Regex.Match(uri.AbsolutePath, @"^/(?<org>[^/]+)(/(?<proj>[^_./:\\~&%;@'""?<>|#$*][^/:\\~&%;@'""?<>|#$*]*))?")
                         is Match match && match.Success)
                 {
                     var orgUri = new Uri(uri, $"/{match.Groups["org"].Value}");
@@ -36,9 +35,8 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
 
             {
                 var match = Regex.Match(uri.AbsolutePath,
-                    @"^(?<prefix>/[^_./:\\~&%;@'""?<>|#$*][^/:\\~&%;@'""?<>|#$*]*)?/[^_./:\\~&%;@'""?<>|#$*][^/:\\~&%;@'""?<>|#$*]*",
-                    RegexOptions.Compiled);
-                var isVsUrl = Regex.IsMatch(uri.Host, @"^[^.]+\.visualstudio\.com$", RegexOptions.Compiled);
+                    @"^(?<prefix>/[^_./:\\~&%;@'""?<>|#$*][^/:\\~&%;@'""?<>|#$*]*)?/[^_./:\\~&%;@'""?<>|#$*][^/:\\~&%;@'""?<>|#$*]*");
+                var isVsUrl = Regex.IsMatch(uri.Host, @"^[^.]+\.visualstudio\.com$");
                 var projectIsSpecified = match.Success
                                          && (match.Groups["prefix"].Success || isVsUrl);
                 var collectionPath = match.Groups["prefix"].Success
@@ -71,7 +69,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
 
             try
             {
-                var prefixMatch = Regex.Match(browserUrl, @"^\s*((https?://.+?)/+[^\/]+)/+_build\b", RegexOptions.Compiled);
+                var prefixMatch = Regex.Match(browserUrl, @"^\s*((https?://.+?)/+[^\/]+)/+_build\b");
                 if (!prefixMatch.Success)
                 {
                     throw ParseError();

--- a/source/Server/AdoClients/HttpJsonClient.cs
+++ b/source/Server/AdoClients/HttpJsonClient.cs
@@ -19,7 +19,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
                    && HttpStatusCode <= (HttpStatusCode) 299;
         }
 
-        public string ToDescription()
+        public string ToDescription(JObject jObject = null, bool disableSettingsHints = false)
         {
             if (!string.IsNullOrWhiteSpace(ErrorMessage))
             {
@@ -29,13 +29,23 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
             if (SignInPage)
             {
                 return "The server returned a sign-in page."
-                       + " Please confirm the Personal Access Token is configured correctly in Azure DevOps Issue Tracker settings.";
+                       + (disableSettingsHints
+                           ? ""
+                           : " Please confirm the Personal Access Token is configured correctly in Azure DevOps Issue Tracker settings.");
             }
 
             var description = $"{(int) HttpStatusCode} ({HttpStatusCode}).";
+            var bodyMessage = jObject?["message"]?.ToString();
+            if (!string.IsNullOrWhiteSpace(bodyMessage))
+            {
+                description += $" \"{bodyMessage}\"";
+            }
+
             if (HttpStatusCode == HttpStatusCode.Unauthorized)
             {
-                description += " Please confirm the Personal Access Token is configured correctly in Azure DevOps Issue Tracker settings.";
+                description += disableSettingsHints
+                    ? " Please confirm you are using a Personal Access Token authorized for this scope."
+                    : " Please confirm the Personal Access Token is configured correctly in Azure DevOps Issue Tracker settings, and is authorized for this scope.";
             }
 
             return description;

--- a/source/Server/AdoClients/HttpJsonClient.cs
+++ b/source/Server/AdoClients/HttpJsonClient.cs
@@ -26,12 +26,12 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
                 return ErrorMessage;
             }
 
+            var authMessage = disableSettingsHints
+                ? $" Please confirm you are using a Personal Access Token authorized {HttpJsonClient.AuthMessageScope}."
+                : $" Please confirm the Personal Access Token is configured correctly in Azure DevOps Issue Tracker settings, and is authorized {HttpJsonClient.AuthMessageScope}.";
             if (SignInPage)
             {
-                return "The server returned a sign-in page."
-                       + (disableSettingsHints
-                           ? ""
-                           : " Please confirm the Personal Access Token is configured correctly in Azure DevOps Issue Tracker settings.");
+                return "The server returned a sign-in page." + authMessage;
             }
 
             var description = $"{(int) HttpStatusCode} ({HttpStatusCode}).";
@@ -43,9 +43,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
 
             if (HttpStatusCode == HttpStatusCode.Unauthorized)
             {
-                description += disableSettingsHints
-                    ? " Please confirm you are using a Personal Access Token authorized for this scope."
-                    : " Please confirm the Personal Access Token is configured correctly in Azure DevOps Issue Tracker settings, and is authorized for this scope.";
+                description += authMessage;
             }
 
             return description;
@@ -61,6 +59,8 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
 
     public sealed class HttpJsonClient : IHttpJsonClient
     {
+        public static string AuthMessageScope = "for this scope";
+
         private readonly HttpClient httpClient = new HttpClient();
 
         public (HttpJsonClientStatus status, JObject jObject) Get(string url, string basicPassword = null)

--- a/source/Server/AzureDevOpsIssueTrackerApi.cs
+++ b/source/Server/AzureDevOpsIssueTrackerApi.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
+using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration;
+using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Web;
+
+namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps
+{
+    public class AzureDevOpsIssueTrackerApi : RegisterEndpoint
+    {
+        public const string ApiConnectivityCheck = "/api/azuredevopsissuetracker/connectivitycheck";
+
+        public AzureDevOpsIssueTrackerApi(
+            Func<SecuredAsyncActionInvoker<AzureDevOpsConnectivityCheckAction, IAzureDevOpsConfigurationStore>> azureDevOpsConnectivityCheckInvokerFactory)
+        {
+            Add("POST", ApiConnectivityCheck, azureDevOpsConnectivityCheckInvokerFactory().ExecuteAsync);
+        }
+    }
+}

--- a/source/Server/AzureDevOpsIssueTrackerExtension.cs
+++ b/source/Server/AzureDevOpsIssueTrackerExtension.cs
@@ -47,6 +47,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps
             builder.RegisterType<HttpJsonClient>()
                 .As<IHttpJsonClient>()
                 .InstancePerDependency();
+            HttpJsonClient.AuthMessageScope = "to read scopes 'Build' and 'Work items'";
 
             builder.RegisterType<AdoApiClient>()
                 .As<IAdoApiClient>()

--- a/source/Server/AzureDevOpsIssueTrackerExtension.cs
+++ b/source/Server/AzureDevOpsIssueTrackerExtension.cs
@@ -4,8 +4,10 @@ using Octopus.Server.Extensibility.Extensions.Infrastructure;
 using Octopus.Server.Extensibility.Extensions.Infrastructure.Configuration;
 using Octopus.Server.Extensibility.Extensions.Mappings;
 using Octopus.Server.Extensibility.Extensions.WorkItems;
+using Octopus.Server.Extensibility.HostServices.Web;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration;
+using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Web;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.WorkItems;
 
 namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps
@@ -49,6 +51,14 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps
             builder.RegisterType<AdoApiClient>()
                 .As<IAdoApiClient>()
                 .InstancePerLifetimeScope();
+
+            builder.RegisterType<AzureDevOpsConnectivityCheckAction>()
+                .AsSelf()
+                .InstancePerDependency();
+
+            builder.RegisterType<AzureDevOpsIssueTrackerHomeLinksContributor>()
+                .As<IHomeLinksContributor>()
+                .InstancePerDependency();
 
             builder.RegisterType<WorkItemLinkMapper>()
                 .As<IWorkItemLinkMapper>()

--- a/source/Server/AzureDevOpsIssueTrackerHomeLinksContributor.cs
+++ b/source/Server/AzureDevOpsIssueTrackerHomeLinksContributor.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Octopus.Server.Extensibility.HostServices.Web;
+
+namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps
+{
+    public class AzureDevOpsIssueTrackerHomeLinksContributor : IHomeLinksContributor
+    {
+        public IDictionary<string, string> GetLinksToContribute()
+        {
+            return new Dictionary<string, string> {{"AzureDevOpsConnectivityCheck", $"~{AzureDevOpsIssueTrackerApi.ApiConnectivityCheck}"}};
+        }
+    }
+}

--- a/source/Server/Configuration/AzureDevOpsConfigurationResource.cs
+++ b/source/Server/Configuration/AzureDevOpsConfigurationResource.cs
@@ -10,7 +10,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration
     public class AzureDevOpsConfigurationResource : ExtensionConfigurationResource
     {
         public const string BaseUrlDisplayName = "Azure DevOps Base Url";
-        public const string BaseUrlDescription = "Set the base url for the Azure DevOps organization or collection.";
+        public const string BaseUrlDescription = "Set the base url for the Azure DevOps organization or collection or project.";
 
         [DisplayName(BaseUrlDisplayName)]
         [Description(BaseUrlDescription)]
@@ -24,6 +24,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration
         [DisplayName("Personal Access Token")]
         [Description(PersonalAccessTokenDescription)]
         [Writeable]
+        [AllowConnectivityCheck("Azure DevOps configuration", AzureDevOpsIssueTrackerApi.ApiConnectivityCheck, nameof(BaseUrl), nameof(PersonalAccessToken))]
         public SensitiveValue PersonalAccessToken { get; set; }
 
         [DisplayName("Release Note Options")]

--- a/source/Server/Web/AzureDevOpsConnectivityCheckAction.cs
+++ b/source/Server/Web/AzureDevOpsConnectivityCheckAction.cs
@@ -41,8 +41,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Web
 
                 if (string.IsNullOrEmpty(baseUrl))
                 {
-                    context.Response.AsOctopusJson(ConnectivityCheckResponse.Failure(
-                        string.IsNullOrEmpty(baseUrl) ? "Please provide a value for Azure DevOps Base Url." : null));
+                    context.Response.AsOctopusJson(ConnectivityCheckResponse.Failure("Please provide a value for Azure DevOps Base Url."));
                     return;
                 }
 

--- a/source/Server/Web/AzureDevOpsConnectivityCheckAction.cs
+++ b/source/Server/Web/AzureDevOpsConnectivityCheckAction.cs
@@ -77,23 +77,17 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Web
                 string lastFailureReason = null;
                 foreach (var projectUrl in projectUrls)
                 {
-                    var builds = adoApiClient.GetBuildList(projectUrl, personalAccessToken, true);
-                    if (!builds.Succeeded)
+                    var buildScopeTest = adoApiClient.GetBuildWorkItemsRefs(AdoBuildUrls.Create(projectUrl, 1), personalAccessToken, true);
+                    if (!buildScopeTest.Succeeded)
                     {
-                        lastFailureReason = builds.FailureReason;
+                        lastFailureReason = buildScopeTest.FailureReason;
                         continue;
                     }
 
-                    if (!builds.Value.Any())
+                    var workItemScopeTest = adoApiClient.GetWorkItem(projectUrl, 1, personalAccessToken, true);
+                    if (!workItemScopeTest.Succeeded)
                     {
-                        lastFailureReason = "Successfully connected, but unable to find any builds to test permissions.";
-                        continue;
-                    }
-
-                    var workItems = adoApiClient.GetBuildWorkItemsRefs(AdoBuildUrls.Create(projectUrl, builds.Value.First()), personalAccessToken, true);
-                    if (!workItems.Succeeded)
-                    {
-                        lastFailureReason = workItems.FailureReason;
+                        lastFailureReason = workItemScopeTest.FailureReason;
                         continue;
                     }
 

--- a/source/Server/Web/AzureDevOpsConnectivityCheckAction.cs
+++ b/source/Server/Web/AzureDevOpsConnectivityCheckAction.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
+using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients;
+using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration;
+using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Web.Response;
+
+namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Web
+{
+    public class AzureDevOpsConnectivityCheckAction : IAsyncApiAction
+    {
+        private readonly IAzureDevOpsConfigurationStore configurationStore;
+        private readonly IAdoApiClient adoApiClient;
+
+        public AzureDevOpsConnectivityCheckAction(IAzureDevOpsConfigurationStore configurationStore, IAdoApiClient adoApiClient)
+        {
+            this.configurationStore = configurationStore;
+            this.adoApiClient = adoApiClient;
+        }
+
+        public async Task ExecuteAsync(OctoContext context)
+        {
+            try
+            {
+                var json = await new StreamReader(context.Request.Body).ReadToEndAsync();
+                var request = JsonConvert.DeserializeObject<JObject>(json);
+
+                var baseUrl = request.GetValue("BaseUrl").ToString();
+                // If PersonalAccessToken here is null, it could be that they're clicking the test connectivity button after saving
+                // the configuration as we won't have the value of the PersonalAccessToken on client side, so we need to retrieve it
+                // from the database
+                var personalAccessToken = request.GetValue("PersonalAccessToken").ToString();
+                if (string.IsNullOrEmpty(personalAccessToken))
+                {
+                    personalAccessToken = configurationStore.GetPersonalAccessToken();
+                }
+
+                if (string.IsNullOrEmpty(baseUrl))
+                {
+                    context.Response.AsOctopusJson(ConnectivityCheckResponse.Failure(
+                        string.IsNullOrEmpty(baseUrl) ? "Please provide a value for Azure DevOps Base Url." : null));
+                    return;
+                }
+
+                var urls = AdoProjectUrls.ParseOrganizationAndProjectUrls(baseUrl);
+                AdoProjectUrls[] projectUrls;
+                if (urls.ProjectUrl != null)
+                {
+                    projectUrls = new[] {urls};
+                }
+                else
+                {
+                    var projects = adoApiClient.GetProjectList(urls, personalAccessToken, true);
+                    if (!projects.Succeeded)
+                    {
+                        context.Response.AsOctopusJson(ConnectivityCheckResponse.Failure(projects.FailureReason));
+                        return;
+                    }
+
+                    if (!projects.Value.Any())
+                    {
+                        context.Response.AsOctopusJson(
+                            ConnectivityCheckResponse.Failure("Successfully connected, but unable to find any projects to test permissions."));
+                        return;
+                    }
+
+                    projectUrls = projects.Value.Select(project => new AdoProjectUrls
+                    {
+                        OrganizationUrl = urls.OrganizationUrl,
+                        ProjectUrl = $"{urls.OrganizationUrl}/{project}"
+                    }).ToArray();
+                }
+
+                string lastFailureReason = null;
+                foreach (var projectUrl in projectUrls)
+                {
+                    var builds = adoApiClient.GetBuildList(projectUrl, personalAccessToken, true);
+                    if (!builds.Succeeded)
+                    {
+                        lastFailureReason = builds.FailureReason;
+                        continue;
+                    }
+
+                    if (!builds.Value.Any())
+                    {
+                        lastFailureReason = "Successfully connected, but unable to find any builds to test permissions.";
+                        continue;
+                    }
+
+                    var workItems = adoApiClient.GetBuildWorkItemsRefs(AdoBuildUrls.Create(projectUrl, builds.Value.First()), personalAccessToken, true);
+                    if (!workItems.Succeeded)
+                    {
+                        lastFailureReason = workItems.FailureReason;
+                        continue;
+                    }
+
+                    context.Response.AsOctopusJson(ConnectivityCheckResponse.Success);
+                    return;
+                }
+
+                context.Response.AsOctopusJson(ConnectivityCheckResponse.Failure(lastFailureReason));
+            }
+            catch (Exception ex)
+            {
+                context.Response.AsOctopusJson(ConnectivityCheckResponse.Failure(ex.ToString()));
+            }
+        }
+    }
+}

--- a/source/Server/Web/Response/ConnectivityCheckResponse.cs
+++ b/source/Server/Web/Response/ConnectivityCheckResponse.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Web.Response
+{
+    public class ConnectivityCheckResponse
+    {
+        public IReadOnlyCollection<string> ErrorMessages { get; }
+
+        public bool WasSuccessful => !ErrorMessages.Any();
+
+        private ConnectivityCheckResponse(IReadOnlyCollection<string> errorMessages)
+        {
+            ErrorMessages = errorMessages;
+        }
+
+        public static ConnectivityCheckResponse Success => new ConnectivityCheckResponse(new string[0]);
+
+        public static ConnectivityCheckResponse Failure(params string[] errorMessages)
+        {
+            var messages = (errorMessages ?? new string[0])
+                .Where(m => !string.IsNullOrWhiteSpace(m))
+                .ToArray();
+            return new ConnectivityCheckResponse(messages.Any()
+                ? messages
+                : new[] {"Connectivity failure."});
+        }
+    }
+}


### PR DESCRIPTION
This change adds a "Test" button in the Azure DevOps Issue Tracker settings, allowing users to immediately confirm the accessibility of the Azure DevOps instance, and the validity of their settings.

The base URL can refer to a collection or project. If it doesn't include a project, we fetch the projects list. The test succeeds if we can find any build and ask for its work items, demonstrating the token has the right scope.

For OctopusDeploy/Issues#6064.