### PR TITLE
add assemblies to cake file

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -112,6 +112,9 @@ Task("__Pack")
 
 		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "net452", $"*.{extensionName}.dll"), extPublishDir);
 		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "net452", $"HtmlAgilityPack.dll"), extPublishDir);
+		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "net452", $"System.Net.Http.Extensions.dll"), extPublishDir);
+		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "net452", $"System.Net.Http.Formatting.dll"), extPublishDir);
+		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "net452", $"System.Net.Http.Primitives.dll"), extPublishDir);
 
         NuGetPack(Path.Combine(extPublishDir, "Server.nuspec"), new NuGetPackSettings {
             Version = nugetVersion,


### PR DESCRIPTION
Adds missing system assemblies to the package

Relates to OctopusDeploy/Issues/issues/6135

![image](https://user-images.githubusercontent.com/5088479/74495962-fa00e100-4f24-11ea-854b-007ad7e9f7c9.png)
