### PR TITLE
Enabling Nullable Reference Types

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -110,9 +110,9 @@ Task("__Pack")
         CreateDirectory(extPublishDir);
         CopyFileToDirectory(Path.Combine("BuildAssets", "Server.nuspec"), extPublishDir);
 
-		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "netstandard2.0", $"*.{extensionName}.dll"), extPublishDir);
-		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "netstandard2.0", $"HtmlAgilityPack.dll"), extPublishDir);
-		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "netstandard2.0", $"System.Net.Http.Formatting.dll"), extPublishDir);
+		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "netstandard2.1", $"*.{extensionName}.dll"), extPublishDir);
+		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "netstandard2.1", $"HtmlAgilityPack.dll"), extPublishDir);
+		CopyFiles(Path.Combine("source", "Server", "bin", "Release", "netstandard2.1", $"System.Net.Http.Formatting.dll"), extPublishDir);
 
         NuGetPack(Path.Combine(extPublishDir, "Server.nuspec"), new NuGetPackSettings {
             Version = nugetVersion,

--- a/source/Server.Tests/AdoApiClientScenarios.cs
+++ b/source/Server.Tests/AdoApiClientScenarios.cs
@@ -3,11 +3,13 @@ using System.Net;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using NUnit.Framework;
+using Octopus.Data;
 using Octopus.Data.Model;
 using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.WorkItems;
+using Octopus.Server.Extensibility.Resources.IssueTrackers;
 
 namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
 {
@@ -47,14 +49,13 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=24"));
 
-            Assert.IsTrue(workItemLinks.WasSuccessful);
-            var workItemLink = workItemLinks.Value.Single();
+            var workItemLink = ((ISuccessResult<WorkItemLink[]>)workItemLinks).Value.Single();
             Assert.AreEqual("2", workItemLink.Id);
             Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=2", workItemLink.LinkUrl);
             Assert.AreEqual("README has no useful content", workItemLink.Description);
         }
 
-        
+
         [Test]
         public void SourceGetsSet()
         {
@@ -70,8 +71,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=24"));
 
-            Assert.IsTrue(workItemLinks.WasSuccessful);
-            var workItemLink = workItemLinks.Value.Single();
+            var workItemLink = ((ISuccessResult<WorkItemLink[]>)workItemLinks).Value.Single();
             Assert.AreEqual("Azure DevOps", workItemLink.Source);
         }
 
@@ -93,8 +93,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=28"));
 
-            Assert.IsTrue(workItemLinks.WasSuccessful);
-            var workItemLink = workItemLinks.Value.Single();
+            var workItemLink = ((ISuccessResult<WorkItemLink[]>)workItemLinks).Value.Single();
             Assert.AreEqual("4", workItemLink.Id);
             Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=4", workItemLink.LinkUrl);
             Assert.AreEqual("README riddle now has an answer!", workItemLink.Description);
@@ -122,14 +121,14 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=29"));
 
-            Assert.IsTrue(workItemLinks.WasSuccessful);
-            Assert.AreEqual(2, workItemLinks.Value.Length);
-            Assert.AreEqual("5", workItemLinks.Value[0].Id);
-            Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=5", workItemLinks.Value[0].LinkUrl);
-            Assert.AreEqual("The README riddle has no answer", workItemLinks.Value[0].Description);
-            Assert.AreEqual("6", workItemLinks.Value[1].Id);
-            Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=6", workItemLinks.Value[1].LinkUrl);
-            Assert.AreEqual("6", workItemLinks.Value[1].Description);
+            var successResult = ((ISuccessResult<WorkItemLink[]>)workItemLinks);
+            Assert.AreEqual(2, successResult.Value.Length);
+            Assert.AreEqual("5", successResult.Value[0].Id);
+            Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=5", successResult.Value[0].LinkUrl);
+            Assert.AreEqual("The README riddle has no answer", successResult.Value[0].Description);
+            Assert.AreEqual("6", successResult.Value[1].Id);
+            Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=6", successResult.Value[1].LinkUrl);
+            Assert.AreEqual("6", successResult.Value[1].Description);
             log.Received().WarnFormat(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>());
         }
 
@@ -169,8 +168,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=7"));
 
-            Assert.IsTrue(workItemLinks.WasSuccessful);
-            Assert.IsEmpty(workItemLinks.Value);
+            Assert.IsEmpty(((ISuccessResult<WorkItemLink[]>)workItemLinks).Value);
         }
 
         [Test]
@@ -188,8 +186,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=8"));
 
-            Assert.IsTrue(workItemLinks.WasSuccessful);
-            var workItemLink = workItemLinks.Value.Single();
+            var workItemLink = ((ISuccessResult<WorkItemLink[]>)workItemLinks).Value.Single();
             Assert.AreEqual("999", workItemLink.Id);
             Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=999", workItemLink.LinkUrl);
             Assert.AreEqual("999", workItemLink.Description);

--- a/source/Server.Tests/AdoApiClientScenarios.cs
+++ b/source/Server.Tests/AdoApiClientScenarios.cs
@@ -17,7 +17,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
     public class AdoApiClientScenarios
     {
         private static readonly HtmlConvert HtmlConvert = new HtmlConvert(Substitute.For<ILog>());
-        private ILog log;
+        private ILog? log;
 
         private static IAzureDevOpsConfigurationStore CreateSubstituteStore()
         {
@@ -46,7 +46,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
                 .Returns((HttpStatusCode.OK,
                     JObject.Parse(@"{""id"":2,""fields"":{""System.CommentCount"":0,""System.Title"": ""README has no useful content""}}")));
 
-            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
+            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log!).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=24"));
 
             var workItemLink = ((ISuccessResult<WorkItemLink[]>)workItemLinks).Value.Single();
@@ -68,7 +68,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
                 .Returns((HttpStatusCode.OK,
                     JObject.Parse(@"{""id"":2,""fields"":{""System.CommentCount"":0,""System.Title"": ""README has no useful content""}}")));
 
-            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
+            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log!).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=24"));
 
             var workItemLink = ((ISuccessResult<WorkItemLink[]>)workItemLinks).Value.Single();
@@ -90,7 +90,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
                 .Returns((HttpStatusCode.OK, JObject.Parse(@"{""totalCount"":3,""count"":3,""comments"":[{""text"":""= Changelog = N/A""}," +
                                                            @"{""text"":""<div>= Changelog =&nbsp;README <i>riddle</i> now has an answer!</div>""},{""text"":""See also related issue.""}]}")));
 
-            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
+            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log!).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=28"));
 
             var workItemLink = ((ISuccessResult<WorkItemLink[]>)workItemLinks).Value.Single();
@@ -118,7 +118,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             httpJsonClient.Get("http://redstoneblock/DefaultCollection/Deployable/_apis/wit/workitems/6/comments?api-version=4.1-preview.2", "rumor")
                 .Returns((HttpStatusCode.InternalServerError, null));
 
-            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
+            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log!).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=29"));
 
             var successResult = ((ISuccessResult<WorkItemLink[]>)workItemLinks);
@@ -129,7 +129,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             Assert.AreEqual("6", successResult.Value[1].Id);
             Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=6", successResult.Value[1].LinkUrl);
             Assert.AreEqual("6", successResult.Value[1].Description);
-            log.Received().WarnFormat(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>());
+            log!.Received().WarnFormat(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>());
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var store = CreateSubstituteStore();
             var httpJsonClient = Substitute.For<IHttpJsonClient>();
             string passwordSent = ".";
-            httpJsonClient.Get(null)
+            httpJsonClient.Get(Arg.Any<string>())
                 .ReturnsForAnyArgs(ci =>
                 {
                     passwordSent = ci.ArgAt<string>(1);
@@ -146,12 +146,12 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
                 });
 
             // Request to other host should not include password
-            new AdoApiClient(store, httpJsonClient, HtmlConvert, log)
+            new AdoApiClient(store, httpJsonClient, HtmlConvert, log!)
                 .GetBuildWorkItemsRefs(AdoBuildUrls.ParseBrowserUrl("http://someotherhost/DefaultCollection/Deployable/_build/results?buildId=24"));
             Assert.IsNull(passwordSent);
 
             // Request to origin should include password
-            new AdoApiClient(store, httpJsonClient, HtmlConvert, log)
+            new AdoApiClient(store, httpJsonClient, HtmlConvert, log!)
                 .GetBuildWorkItemsRefs(AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=24"));
             Assert.AreEqual("rumor", passwordSent);
         }
@@ -165,7 +165,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
                 .Returns((HttpStatusCode.NotFound,
                     JObject.Parse(@"{""$id"":""1"",""message"":""The requested build 7 could not be found."",""errorCode"":0,""eventId"":3000}")));
 
-            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
+            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log!).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=7"));
 
             Assert.IsEmpty(((ISuccessResult<WorkItemLink[]>)workItemLinks).Value);
@@ -183,7 +183,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
                 .Returns((HttpStatusCode.NotFound,
                     JObject.Parse(@"{""$id"":""1"",""message"":""TF401232: Work item 999 does not exist."",""errorCode"":0,""eventId"":3200}")));
 
-            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log).GetBuildWorkItemLinks(
+            var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert, log!).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=8"));
 
             var workItemLink = ((ISuccessResult<WorkItemLink[]>)workItemLinks).Value.Single();

--- a/source/Server.Tests/AdoApiClientScenarios.cs
+++ b/source/Server.Tests/AdoApiClientScenarios.cs
@@ -40,7 +40,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=24"));
 
-            Assert.IsTrue(workItemLinks.Succeeded);
+            Assert.IsTrue(workItemLinks.WasSuccessful);
             var workItemLink = workItemLinks.Value.Single();
             Assert.AreEqual("2", workItemLink.Id);
             Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=2", workItemLink.LinkUrl);
@@ -63,7 +63,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=24"));
 
-            Assert.IsTrue(workItemLinks.Succeeded);
+            Assert.IsTrue(workItemLinks.WasSuccessful);
             var workItemLink = workItemLinks.Value.Single();
             Assert.AreEqual("Azure DevOps", workItemLink.Source);
         }
@@ -86,7 +86,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=28"));
 
-            Assert.IsTrue(workItemLinks.Succeeded);
+            Assert.IsTrue(workItemLinks.WasSuccessful);
             var workItemLink = workItemLinks.Value.Single();
             Assert.AreEqual("4", workItemLink.Id);
             Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=4", workItemLink.LinkUrl);
@@ -115,8 +115,8 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=29"));
 
-            Assert.IsFalse(workItemLinks.Succeeded);
-            Assert.AreEqual("Error while fetching work item comments from Azure DevOps: 500 (InternalServerError).", workItemLinks.FailureReason);
+            Assert.IsFalse(workItemLinks.WasSuccessful);
+            Assert.AreEqual("Error while fetching work item comments from Azure DevOps: 500 (InternalServerError).", workItemLinks.ErrorString);
             Assert.AreEqual(2, workItemLinks.Value.Length);
             Assert.AreEqual("5", workItemLinks.Value[0].Id);
             Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=5", workItemLinks.Value[0].LinkUrl);
@@ -162,7 +162,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=7"));
 
-            Assert.IsTrue(workItemLinks.Succeeded);
+            Assert.IsTrue(workItemLinks.WasSuccessful);
             Assert.IsEmpty(workItemLinks.Value);
         }
 
@@ -181,7 +181,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var workItemLinks = new AdoApiClient(store, httpJsonClient, HtmlConvert).GetBuildWorkItemLinks(
                 AdoBuildUrls.ParseBrowserUrl("http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=8"));
 
-            Assert.IsTrue(workItemLinks.Succeeded);
+            Assert.IsTrue(workItemLinks.WasSuccessful);
             var workItemLink = workItemLinks.Value.Single();
             Assert.AreEqual("999", workItemLink.Id);
             Assert.AreEqual("http://redstoneblock/DefaultCollection/Deployable/_workitems?_a=edit&id=999", workItemLink.LinkUrl);

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0010" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0003" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
 

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests</AssemblyName>
     <RootNamespace>Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests</RootNamespace>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,8 +14,6 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0003" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
 

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests</AssemblyName>
     <RootNamespace>Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests</RootNamespace>
   </PropertyGroup>
@@ -12,8 +12,8 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0010" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
 

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -21,14 +21,14 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
         }
 
         [Test]
-        public void WhenDisabledReturnsNull()
+        public void WhenDisabledReturnsExtensionIsDisabled()
         {
             var links = CreateWorkItemLinkMapper(false).Map(new OctopusBuildInformation
             {
                 BuildUrl = "http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=24"
             });
-            Assert.IsTrue(links.WasSuccessful);
-            Assert.IsNull(links.Value);
+            Assert.IsFalse(links.WasSuccessful);
+            Assert.IsTrue(links.ExtensionIsDisabled);
         }
     }
 }

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -17,7 +17,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             var config = Substitute.For<IAzureDevOpsConfigurationStore>();
             config.GetIsEnabled().Returns(enabled);
             var adoApiClient = Substitute.For<IAdoApiClient>();
-            adoApiClient.GetBuildWorkItemLinks(null).ReturnsForAnyArgs(ci => throw new InvalidOperationException());
+            adoApiClient.GetBuildWorkItemLinks(new AdoBuildUrls("http://redstoneblock", 24)).ReturnsForAnyArgs(ci => throw new InvalidOperationException());
             return new WorkItemLinkMapper(config, adoApiClient);
         }
 

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using NSubstitute;
 using NUnit.Framework;
-using Octopus.Server.Extensibility.Extensions;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
-using Octopus.Server.Extensibility.HostServices.Model.IssueTrackers;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.WorkItems;
-using Octopus.Server.Extensibility.Resources.IssueTrackers;
 
 namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
 {
@@ -30,7 +27,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             {
                 BuildUrl = "http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=24"
             });
-            Assert.IsTrue(links.Succeeded);
+            Assert.IsTrue(links.WasSuccessful);
             Assert.IsNull(links.Value);
         }
     }

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -5,6 +5,7 @@ using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.WorkItems;
+using Octopus.Server.Extensibility.Results;
 
 namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
 {
@@ -27,8 +28,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Tests
             {
                 BuildUrl = "http://redstoneblock/DefaultCollection/Deployable/_build/results?buildId=24"
             });
-            Assert.IsFalse(links.WasSuccessful);
-            Assert.IsTrue(links.ExtensionIsDisabled);
+            Assert.IsInstanceOf<IFailureResultFromDisabledExtension>(links);
         }
     }
 }

--- a/source/Server/AdoClients/AdoApiClient.cs
+++ b/source/Server/AdoClients/AdoApiClient.cs
@@ -45,7 +45,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
                 var baseUrl = store.GetBaseUrl();
                 if (baseUrl == null)
                     return null;
-                var uri = new Uri(baseUrl?.TrimEnd('/'), UriKind.Absolute);
+                var uri = new Uri(baseUrl.TrimEnd('/'), UriKind.Absolute);
                 return uri.IsBaseOf(new Uri(adoUrl.OrganizationUrl, UriKind.Absolute)) ? store.GetPersonalAccessToken()?.Value : null;
             }
             catch

--- a/source/Server/AdoClients/HttpJsonClient.cs
+++ b/source/Server/AdoClients/HttpJsonClient.cs
@@ -12,7 +12,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
     {
         public HttpStatusCode HttpStatusCode { get; set; }
         public bool SignInPage { get; set; }
-        public string ErrorMessage { get; set; }
+        public string ErrorMessage { get; set; } = string.Empty;
 
         public bool IsSuccessStatusCode()
         {
@@ -20,7 +20,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
                    && HttpStatusCode <= (HttpStatusCode) 299;
         }
 
-        public string ToDescription(JObject jObject = null, bool disableSettingsHints = false)
+        public string ToDescription(JObject? jObject = null, bool disableSettingsHints = false)
         {
             if (!string.IsNullOrWhiteSpace(ErrorMessage))
             {
@@ -55,7 +55,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
 
     interface IHttpJsonClient : IDisposable
     {
-        (HttpJsonClientStatus status, JObject jObject) Get(string url, string basicPassword = null);
+        (HttpJsonClientStatus status, JObject? jObject) Get(string url, string? basicPassword = null);
     }
 
     sealed class HttpJsonClient : IHttpJsonClient
@@ -69,7 +69,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
             httpClient = octopusHttpClientFactory.CreateClient();
         }
         
-        public (HttpJsonClientStatus status, JObject jObject) Get(string url, string basicPassword = null)
+        public (HttpJsonClientStatus status, JObject? jObject) Get(string url, string? basicPassword = null)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -109,8 +109,11 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
             }
         }
 
-        private JObject ParseJsonOrDefault(HttpContent httpContent)
+        private JObject? ParseJsonOrDefault(HttpContent? httpContent)
         {
+            if (httpContent == null)
+                return null;
+            
             try
             {
                 return JObject.Parse(httpContent.ReadAsStringAsync().GetAwaiter().GetResult());

--- a/source/Server/AzureDevOpsIssueTracker.cs
+++ b/source/Server/AzureDevOpsIssueTracker.cs
@@ -19,6 +19,6 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps
 
         public bool IsEnabled => configurationStore.GetIsEnabled();
 
-        public string BaseUrl => configurationStore.GetIsEnabled() ? configurationStore.GetBaseUrl() : null;
+        public string? BaseUrl => configurationStore.GetIsEnabled() ? configurationStore.GetBaseUrl() : null;
     }
 }

--- a/source/Server/Configuration/AzureDevOpsConfiguration.cs
+++ b/source/Server/Configuration/AzureDevOpsConfiguration.cs
@@ -9,15 +9,15 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration
         {
         }
 
-        public string BaseUrl { get; set; }
+        public string? BaseUrl { get; set; }
 
-        public SensitiveString PersonalAccessToken { get; set; }
+        public SensitiveString? PersonalAccessToken { get; set; }
 
         public ReleaseNoteOptions ReleaseNoteOptions { get; set; } = new ReleaseNoteOptions();
     }
 
     class ReleaseNoteOptions
     {
-        public string ReleaseNotePrefix { get; set; }
+        public string? ReleaseNotePrefix { get; set; }
     }
 }

--- a/source/Server/Configuration/AzureDevOpsConfigurationResource.cs
+++ b/source/Server/Configuration/AzureDevOpsConfigurationResource.cs
@@ -16,7 +16,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration
         [Description(BaseUrlDescription)]
         [Required]
         [Writeable]
-        public string BaseUrl { get; set; }
+        public string? BaseUrl { get; set; }
 
         public const string PersonalAccessTokenDescription =
             "A Personal Access Token (PAT) authorized to read scopes 'Build' and 'Work items', added under User Settings.";
@@ -25,7 +25,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration
         [Description(PersonalAccessTokenDescription)]
         [Writeable]
         [AllowConnectivityCheck("Azure DevOps configuration", AzureDevOpsIssueTrackerApi.ApiConnectivityCheck, nameof(BaseUrl), nameof(PersonalAccessToken))]
-        public SensitiveValue PersonalAccessToken { get; set; }
+        public SensitiveValue? PersonalAccessToken { get; set; }
 
         [DisplayName("Release Note Options")]
         public ReleaseNoteOptionsResource ReleaseNoteOptions { get; set; } = new ReleaseNoteOptionsResource();
@@ -39,6 +39,6 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration
         [DisplayName("Release Note Prefix")]
         [Description(ReleaseNotePrefixDescription)]
         [Writeable]
-        public string ReleaseNotePrefix { get; set; }
+        public string? ReleaseNotePrefix { get; set; }
     }
 }

--- a/source/Server/Configuration/AzureDevOpsConfigurationSettings.cs
+++ b/source/Server/Configuration/AzureDevOpsConfigurationSettings.cs
@@ -24,13 +24,13 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration
             var isEnabled = ConfigurationDocumentStore.GetIsEnabled();
             yield return new ConfigurationValue<bool>("Octopus.IssueTracker.AzureDevOpsIssueTracker", isEnabled,
                 isEnabled, "Is Enabled");
-            yield return new ConfigurationValue<string>("Octopus.IssueTracker.AzureDevOpsBaseUrl", ConfigurationDocumentStore.GetBaseUrl(),
+            yield return new ConfigurationValue<string?>("Octopus.IssueTracker.AzureDevOpsBaseUrl", ConfigurationDocumentStore.GetBaseUrl(),
                 isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetBaseUrl()),
                 AzureDevOpsConfigurationResource.BaseUrlDisplayName);
-            yield return new ConfigurationValue<SensitiveString>("Octopus.IssueTracker.AzureDevOpsPersonalAccessToken",
+            yield return new ConfigurationValue<SensitiveString?>("Octopus.IssueTracker.AzureDevOpsPersonalAccessToken",
                 ConfigurationDocumentStore.GetPersonalAccessToken(),
                 false, "Azure DevOps Personal Access Token");
-            yield return new ConfigurationValue<string>("Octopus.IssueTracker.AzureDevOpsReleaseNotePrefix",
+            yield return new ConfigurationValue<string?>("Octopus.IssueTracker.AzureDevOpsReleaseNotePrefix",
                 ConfigurationDocumentStore.GetReleaseNotePrefix(),
                 isEnabled && !string.IsNullOrWhiteSpace(ConfigurationDocumentStore.GetReleaseNotePrefix()), "AzureDevOps Release Note Prefix");
         }

--- a/source/Server/Configuration/AzureDevOpsConfigurationStore.cs
+++ b/source/Server/Configuration/AzureDevOpsConfigurationStore.cs
@@ -16,19 +16,19 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration
 
         public override string Id => SingletonId;
 
-        public string GetBaseUrl()
+        public string? GetBaseUrl()
         {
             return GetProperty(doc => doc.BaseUrl?.Trim('/'));
         }
 
-        public void SetBaseUrl(string baseUrl)
+        public void SetBaseUrl(string? baseUrl)
         {
             SetProperty(doc => doc.BaseUrl = baseUrl?.Trim('/'));
         }
 
-        public SensitiveString GetPersonalAccessToken() => GetProperty(doc => doc.PersonalAccessToken);
-        public void SetPersonalAccessToken(SensitiveString value) => SetProperty(doc => doc.PersonalAccessToken = value);
-        public string GetReleaseNotePrefix() => GetProperty(doc => doc.ReleaseNoteOptions.ReleaseNotePrefix);
-        public void SetReleaseNotePrefix(string releaseNotePrefix) => SetProperty(doc => doc.ReleaseNoteOptions.ReleaseNotePrefix = releaseNotePrefix);
+        public SensitiveString? GetPersonalAccessToken() => GetProperty(doc => doc.PersonalAccessToken);
+        public void SetPersonalAccessToken(SensitiveString? value) => SetProperty(doc => doc.PersonalAccessToken = value);
+        public string? GetReleaseNotePrefix() => GetProperty(doc => doc.ReleaseNoteOptions.ReleaseNotePrefix);
+        public void SetReleaseNotePrefix(string? releaseNotePrefix) => SetProperty(doc => doc.ReleaseNoteOptions.ReleaseNotePrefix = releaseNotePrefix);
     }
 }

--- a/source/Server/Configuration/IAzureDevOpsConfigurationStore.cs
+++ b/source/Server/Configuration/IAzureDevOpsConfigurationStore.cs
@@ -5,12 +5,12 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration
 {
     interface IAzureDevOpsConfigurationStore : IExtensionConfigurationStore<AzureDevOpsConfiguration>
     {
-        string GetBaseUrl();
-        void SetBaseUrl(string baseUrl);
+        string? GetBaseUrl();
+        void SetBaseUrl(string? baseUrl);
 
-        SensitiveString GetPersonalAccessToken();
-        void SetPersonalAccessToken(SensitiveString value);
-        string GetReleaseNotePrefix();
-        void SetReleaseNotePrefix(string releaseNotePrefix);
+        SensitiveString? GetPersonalAccessToken();
+        void SetPersonalAccessToken(SensitiveString? value);
+        string? GetReleaseNotePrefix();
+        void SetReleaseNotePrefix(string? releaseNotePrefix);
     }
 }

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -15,9 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.4" />
-    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0010" />
+    <PackageReference Include="Octopus.Data" Version="5.1.2-ci0001" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0003" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Octopus.Server.Extensibility.IssueTracker.AzureDevOps</AssemblyName>
     <RootNamespace>Octopus.Server.Extensibility.IssueTracker.AzureDevOps</RootNamespace>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -10,13 +10,14 @@
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/OctopusDeploy/AzureDevOpsIssueTracker/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/OctopusDeploy/AzureDevOpsIssueTracker</PackageProjectUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.4" />
-    <PackageReference Include="Octopus.Data" Version="5.0.0" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="9.0.0" />
+    <PackageReference Include="Octopus.Data" Version="5.0.4-enh-nullable0008" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.2-enh-nullable0003" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="9.1.1-enh-nullable0010" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -11,13 +11,14 @@
     <PackageLicenseUrl>https://github.com/OctopusDeploy/AzureDevOpsIssueTracker/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/OctopusDeploy/AzureDevOpsIssueTracker</PackageProjectUrl>
     <Nullable>enable</Nullable>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.4" />
-    <PackageReference Include="Octopus.Data" Version="5.1.2-ci0001" />
-    <PackageReference Include="Octopus.Diagnostics" Version="1.3.4" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2-ci0003" />
+    <PackageReference Include="Octopus.Data" Version="5.1.2" />
+    <PackageReference Include="Octopus.Diagnostics" Version="1.3.5" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="10.0.2" />
   </ItemGroup>
 
 </Project>

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -1,9 +1,11 @@
-﻿using Octopus.Server.Extensibility.Extensions;
+﻿using System;
+using Octopus.Server.Extensibility.Extensions;
 using Octopus.Server.Extensibility.Extensions.WorkItems;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.Configuration;
 using Octopus.Server.Extensibility.Resources.IssueTrackers;
+using Octopus.Server.Extensibility.Results;
 
 namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.WorkItems
 {
@@ -21,13 +23,13 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.WorkItems
         public string CommentParser => AzureDevOpsConfigurationStore.CommentParser;
         public bool IsEnabled => store.GetIsEnabled();
 
-        public SuccessOrErrorResult<WorkItemLink[]> Map(OctopusBuildInformation buildInformation)
+        public ResultFromExtension<WorkItemLink[]> Map(OctopusBuildInformation buildInformation)
         {
             // For ADO, we should ignore anything that wasn't built by ADO because we get work items from the build
             if (!IsEnabled
                 || buildInformation?.BuildEnvironment != "Azure DevOps"
                 || string.IsNullOrWhiteSpace(buildInformation?.BuildUrl))
-                return null;
+                return ResultFromExtension<WorkItemLink[]>.Success(Array.Empty<WorkItemLink>());
 
             return client.GetBuildWorkItemLinks(AdoBuildUrls.ParseBrowserUrl(buildInformation.BuildUrl));
         }

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -22,7 +22,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.WorkItems
         public string CommentParser => AzureDevOpsConfigurationStore.CommentParser;
         public bool IsEnabled => store.GetIsEnabled();
 
-        public ResultFromExtension<WorkItemLink[]> Map(OctopusBuildInformation buildInformation)
+        public IResultFromExtension<WorkItemLink[]> Map(OctopusBuildInformation buildInformation)
         {
             // For ADO, we should ignore anything that wasn't built by ADO because we get work items from the build
             if (!IsEnabled)

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Octopus.Server.Extensibility.Extensions;
 using Octopus.Server.Extensibility.Extensions.WorkItems;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients;
@@ -26,8 +25,9 @@ namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.WorkItems
         public ResultFromExtension<WorkItemLink[]> Map(OctopusBuildInformation buildInformation)
         {
             // For ADO, we should ignore anything that wasn't built by ADO because we get work items from the build
-            if (!IsEnabled
-                || buildInformation?.BuildEnvironment != "Azure DevOps"
+            if (!IsEnabled)
+                return ResultFromExtension<WorkItemLink[]>.ExtensionDisabled();
+            if (buildInformation?.BuildEnvironment != "Azure DevOps"
                 || string.IsNullOrWhiteSpace(buildInformation?.BuildUrl))
                 return ResultFromExtension<WorkItemLink[]>.Success(Array.Empty<WorkItemLink>());
 


### PR DESCRIPTION
Changing the method return types to align with the new nullable patterns we've set up in ServerExtensibility.

Depends on:
OctopusDeploy/ServerExtensibility#66