### PR TITLE
Fetch work items associated with the build changes as well

### DIFF
--- a/source/Server/AdoClients/AdoApiClient.cs
+++ b/source/Server/AdoClients/AdoApiClient.cs
@@ -14,6 +14,7 @@ using Octopus.Server.Extensibility.Results;
 
 namespace Octopus.Server.Extensibility.IssueTracker.AzureDevOps.AdoClients
 {
+    //TODO: May consider replacing this client with the Microsoft.TeamFoundationServer.Client, please refer to https://docs.microsoft.com/en-us/azure/devops/integrate/concepts/dotnet-client-libraries?view=azure-devops
     interface IAdoApiClient
     {
         IResultFromExtension<(int id, string url)[]> GetBuildWorkItemsRefs(AdoBuildUrls adoBuildUrls, string? personalAccessToken = null, bool testing = false);


### PR DESCRIPTION
# Background 

When a work item is associated with the change in the CI build triggered by a gated check-in build, the work item is missing at Octopus Server.

# Result 
Fetching work items associated with build changes as well when invoking `GetBuildWorkItemsRefs`.

![image](https://user-images.githubusercontent.com/12688884/108443214-2243be00-72a4-11eb-91cc-e667493b33c5.png)

## Before

![image](https://user-images.githubusercontent.com/12688884/108453815-f2ea7c80-72b6-11eb-9fc6-f2d1727cd091.png)

## After

![image](https://user-images.githubusercontent.com/12688884/108453702-bb7bd000-72b6-11eb-9bee-d217844fee38.png)

# Issues

https://github.com/OctopusDeploy/Issues/issues/6749