### PR TITLE
Use non-ILMerged version of Octopus Client

### DIFF
--- a/source/Client/Client.csproj
+++ b/source/Client/Client.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Client" Version="7.2.0" />
+    <PackageReference Include="Octopus.Server.Client" Version="11.2.3319" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Background

This pull request depends on https://github.com/OctopusDeploy/OctopusClients/pull/587.

For historical reasons, we need a version of `Octopus.Client.nupkg` which contains a single DLL which is ILMerged so that it can be loaded by a single line in a PowerShell script.

For modern reasons, we need a version (now called `Octopus.Server.Client.nupkg`) which contains a DLL which is _not_ ILMerged and has the usual references to other libraries like `Octopus.TinyTypes`, `Newtonsoft.Json` etc.

# Results

This PR updates this library to have a dependency only on the non-ILMerged `Octopus.Server.Client` package.

Our serialisation approach can now cope with tiny types in message contracts.